### PR TITLE
Fixes issue where 0 redirects will use default values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ function extend(defaults) {
       options = {}
 
     // setup defaults
-    var redirects = options.redirects || defaults.redirects
+    var redirects = options.redirects || ( options.redirects !== 0 ? defaults.redirects : 0 )
     var timeout = options.timeout || defaults.timeout
     var netrc = options.netrc ? Netrc(options.netrc) : defaults.netrc
 


### PR DESCRIPTION
0 redirects is casted to false, thus will use the default value of three.
